### PR TITLE
fix a lot of warning under Delphi 10.3

### DIFF
--- a/Source/TB2Acc.pas
+++ b/Source/TB2Acc.pas
@@ -34,7 +34,7 @@ interface
 {$I TB2Ver.inc}
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  Types, Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   {$IFDEF CLR} System.Runtime.InteropServices, {$ENDIF}
   TB2Item;
 
@@ -247,7 +247,7 @@ var
 implementation
 
 uses
-  {$IFDEF CLR} System.Security, System.Threading, Types, {$ENDIF}
+  {$IFDEF CLR} System.Security, System.Threading, {$ENDIF}
   {$IFNDEF CLR} {$IFDEF JR_D6} Variants, {$ENDIF} {$ENDIF}
   ActiveX, Menus, TB2Common;
 

--- a/Source/TB2Common.pas
+++ b/Source/TB2Common.pas
@@ -31,7 +31,7 @@ interface
 {$I TB2Ver.inc}
 
 uses
-  Windows, Classes, SysUtils, Messages, Controls, Forms;
+  Types, Windows, Classes, SysUtils, Messages, Controls, Forms;
 
 type
   THandleWMPrintNCPaintProc = procedure(Wnd: HWND; DC: HDC; AppData: TObject);
@@ -126,7 +126,7 @@ const
 implementation
 
 uses
-  {$IFDEF CLR} Types, System.Security, System.Runtime.InteropServices,
+  {$IFDEF CLR} System.Security, System.Runtime.InteropServices,
     System.Text, MultiMon, {$ENDIF}
   MMSYSTEM, TB2Version;
 

--- a/Source/TB2Dock.pas
+++ b/Source/TB2Dock.pas
@@ -37,7 +37,7 @@ interface
 {$I TB2Ver.inc}
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, IniFiles;
+  Types, Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, IniFiles;
 
 type
   TTBCustomForm = {$IFDEF JR_D3} TCustomForm {$ELSE} TForm {$ENDIF};
@@ -574,7 +574,7 @@ function TBValidToolWindowParentForm(const ToolWindow: TTBCustomDockableWindow):
 implementation
 
 uses
-  {$IFDEF CLR} Types, System.Runtime.InteropServices, {$ENDIF}
+  {$IFDEF CLR} System.Runtime.InteropServices, {$ENDIF}
   Registry, Consts, Menus,
   TB2Common, TB2Hook, TB2Consts;
 

--- a/Source/TB2Item.pas
+++ b/Source/TB2Item.pas
@@ -38,9 +38,10 @@ interface
     XP with themes enabled. }
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  Types, Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   {$IFDEF CLR} TB2OleMarshal, {$ENDIF}
-  StdCtrls, CommCtrl, Menus, ActnList, ImgList, TB2Anim;
+  StdCtrls, CommCtrl, Menus, ActnList, ImgList, {$IFDEF JR_D17} UITypes,{$ENDIF}
+  TB2Anim;
 
 const
   WM_TB2K_POPUPSHOWING = WM_USER + 554;
@@ -914,7 +915,7 @@ implementation
 
 uses
   {$IFDEF CLR} System.Runtime.InteropServices, System.Text, System.Threading,
-    Types, WinUtils, {$ENDIF}
+    WinUtils, {$ENDIF}
   MMSYSTEM, TB2Consts, TB2Common, IMM, TB2Acc;
 
 function tbMenuVerticalMargin: Integer;
@@ -4865,7 +4866,6 @@ var
   Ctl: TControl;
   ChangedBold: Boolean;
   I, HighestSameWidthViewerWidth, Total, J, TotalVisibleItems: Integer;
-  IsFirst: Boolean;
   Viewer: TTBItemViewer;
   UseChevron, NonControlsOffEdge, TempViewerCreated: Boolean;
   Margins: TRect;


### PR DESCRIPTION
> [dcc32 Hint] TB2Common.pas(458): H2443 Inline function 'TList.Remove' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Acc.pas(1004): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Acc.pas(1026): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Item.pas(1876): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Item.pas(2060): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Item.pas(3326): H2443 Inline function 'TFont.GetStyle' has not been expanded because unit 'System.UITypes' is not specified in USES list
[dcc32 Hint] TB2Item.pas(4243): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Item.pas(4973): H2443 Inline function 'TFont.GetStyle' has not been expanded because unit 'System.UITypes' is not specified in USES list
[dcc32 Hint] TB2Item.pas(4975): H2443 Inline function 'TFont.GetStyle' has not been expanded because unit 'System.UITypes' is not specified in USES list
[dcc32 Hint] TB2Item.pas(5002): H2443 Inline function 'TFont.GetStyle' has not been expanded because unit 'System.UITypes' is not specified in USES list
[dcc32 Hint] TB2Item.pas(5727): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Item.pas(7212): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(1250): H2443 Inline function 'TList.Remove' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(1709): H2443 Inline function 'TList.Remove' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(1737): H2443 Inline function 'TList.Remove' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(1738): H2443 Inline function 'TList.Remove' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(1765): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(2305): H2443 Inline function 'SmallPointToPoint' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(2371): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(3622): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(3629): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(3752): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(3757): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(4209): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(4213): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(4214): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(4218): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(4219): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(4262): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(4479): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(4504): H2443 Inline function 'SmallPointToPoint' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(4699): H2443 Inline function 'SmallPointToPoint' has not been expanded because unit 'System.Types' is not specified in USES list
[dcc32 Hint] TB2Dock.pas(4725): H2443 Inline function 'Point' has not been expanded because unit 'System.Types' is not specified in USES list